### PR TITLE
Verification of compact proofs for Modified Merkle-Patricia tries

### DIFF
--- a/contracts/MerkleProof.sol
+++ b/contracts/MerkleProof.sol
@@ -1,0 +1,401 @@
+// SPDX-License-Identifier: MIT
+
+// Modified Merkle-Patricia Trie
+//
+// Note that for the following definitions, `|` denotes concatenation
+//
+// Branch encoding:
+// NodeHeader | Extra partial key length | Partial Key | Value
+// `NodeHeader` is a byte such that:
+// most significant two bits of `NodeHeader`: 10 if branch w/o value, 11 if branch w/ value
+// least significant six bits of `NodeHeader`: if len(key) > 62, 0x3f, otherwise len(key)
+// `Extra partial key length` is included if len(key) > 63 and consists of the remaining key length
+// `Partial Key` is the branch's key
+// `Value` is: Children Bitmap | SCALE Branch node Value | Hash(Enc(Child[i_1])) | Hash(Enc(Child[i_2])) | ... | Hash(Enc(Child[i_n]))
+//
+// Leaf encoding:
+// NodeHeader | Extra partial key length | Partial Key | Value
+// `NodeHeader` is a byte such that:
+// most significant two bits of `NodeHeader`: 01
+// least significant six bits of `NodeHeader`: if len(key) > 62, 0x3f, otherwise len(key)
+// `Extra partial key length` is included if len(key) > 63 and consists of the remaining key length
+// `Partial Key` is the leaf's key
+// `Value` is the leaf's SCALE encoded value
+
+pragma solidity >=0.5.0 <0.6.0;
+pragma experimental ABIEncoderV2;
+
+import "./common/Input.sol";
+import "./common/Bytes.sol";
+import "./common/Hash.sol";
+import "./common/Nibble.sol";
+import "./common/Node.sol";
+
+/**
+ * @dev Verification of compact proofs for Modified Merkle-Patricia tries.
+ */
+contract MerkleProof {
+    using Bytes for bytes;
+    using Input for Input.Data;
+
+    uint8 internal constant NODEKIND_NOEXT_LEAF = 1;
+    uint8 internal constant NODEKIND_NOEXT_BRANCH_NOVALUE = 2;
+    uint8 internal constant NODEKIND_NOEXT_BRANCH_WITHVALUE = 3;
+
+    struct StackEntry {
+        bytes prefix; // The prefix is the nibble path to the node in the trie.
+        uint8 kind; // The type of the trie node.
+        bytes key; // The partail key of the trie node.
+        bytes value; // The value associated with this trie node.
+        Node.NodeHandle[16] children; // The child references to use in reconstructing the trie nodes.
+        uint8 childIndex; // The child index is in [0, NIBBLE_LENGTH],
+        bool isInline; // The trie node data less 32-byte is an isline node
+    }
+
+    struct ProofIter {
+        bytes[] proof;
+        uint256 offset;
+    }
+
+    struct ItemsIter {
+        Item[] items;
+        uint256 offset;
+    }
+
+    struct Item {
+        bytes key;
+        bytes value;
+    }
+
+    enum ValueMatch {MatchesLeaf, MatchesBranch, NotOmitted, NotFound, IsChild}
+
+    enum Step {Descend, UnwindStack}
+
+    /**
+     * @dev Returns true if `keys ans values` can be proved to be a part of a Merkle tree
+     * defined by `root`. For this, a `proof` must be provided, containing
+     * sibling hashes on the branch from the leaf to the root of the tree. Each
+     * pair of leaves and each pair of pre-images are assumed to be sorted.
+     */
+    function verify(
+        bytes32 root,
+        bytes[] memory proof,
+        bytes[] memory keys,
+        bytes[] memory values
+    ) public view returns (bool) {
+        require(proof.length > 0, "no proof");
+        require(keys.length > 0, "no keys");
+        require(keys.length == values.length, "invalid pair");
+        Item[] memory items = new Item[](keys.length);
+        for (uint256 i = 0; i < keys.length; i++) {
+            items[i] = Item({key: keys[i], value: values[i]});
+        }
+        return verify_proof(root, proof, items);
+    }
+
+    function verify_proof(
+        bytes32 root,
+        bytes[] memory proof,
+        Item[] memory items
+    ) internal view returns (bool) {
+        require(proof.length > 0, "no proof");
+        require(items.length > 0, "no item");
+        //TODO:: OPT
+        uint256 maxDepth = proof.length;
+        StackEntry[] memory stack = new StackEntry[](maxDepth);
+        uint256 stackLen = 0;
+        bytes memory rootNode = proof[0];
+        StackEntry memory lastEntry = decodeNode(rootNode, hex"", false);
+        ProofIter memory proofIter = ProofIter({proof: proof, offset: 1});
+        ItemsIter memory itemsIter = ItemsIter({items: items, offset: 0});
+        while (true) {
+            Step step;
+            bytes memory childPrefix;
+            (step, childPrefix) = advanceItem(lastEntry, itemsIter);
+            if (step == Step.Descend) {
+                StackEntry memory nextEntry = advanceChildIndex(
+                    lastEntry,
+                    childPrefix,
+                    proofIter
+                );
+                stack[stackLen] = lastEntry;
+                stackLen++;
+                lastEntry = nextEntry;
+            } else if (step == Step.UnwindStack) {
+                bytes memory childRef;
+                {
+                    bool isInline = lastEntry.isInline;
+                    bytes memory nodeData = encodeNode(lastEntry);
+                    if (isInline) {
+                        require(
+                            nodeData.length <= 32,
+                            "invalid child reference"
+                        );
+                        childRef = nodeData;
+                    } else {
+                        childRef = Hash.hash(nodeData);
+                    }
+                }
+                {
+                    if (stackLen > 0) {
+                        lastEntry = stack[stackLen - 1];
+                        stackLen--;
+                        lastEntry.children[lastEntry.childIndex]
+                            .data = childRef;
+                    } else {
+                        require(
+                            proofIter.offset == proofIter.proof.length,
+                            "exraneous proof"
+                        );
+                        require(
+                            childRef.length == 32,
+                            "root hash length should be 32"
+                        );
+                        bytes32 computedRoot = abi.decode(childRef, (bytes32));
+                        if (computedRoot != root) {
+                            return false;
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+        return true;
+    }
+
+    function advanceChildIndex(
+        StackEntry memory entry,
+        bytes memory childPrefix,
+        ProofIter memory proofIter
+    ) internal pure returns (StackEntry memory) {
+        if (
+            entry.kind == NODEKIND_NOEXT_BRANCH_NOVALUE ||
+            entry.kind == NODEKIND_NOEXT_BRANCH_WITHVALUE
+        ) {
+            require(childPrefix.length > 0, "this is a branch");
+            entry.childIndex = uint8(childPrefix[childPrefix.length - 1]);
+            Node.NodeHandle memory child = entry.children[entry.childIndex];
+            return makeChildEntry(proofIter, child, childPrefix);
+        } else {
+            revert("cannot have children");
+        }
+    }
+
+    function makeChildEntry(
+        ProofIter memory proofIter,
+        Node.NodeHandle memory child,
+        bytes memory prefix
+    ) internal pure returns (StackEntry memory) {
+        if (child.isInline) {
+            if (child.data.length == 0) {
+                require(
+                    proofIter.offset < proofIter.proof.length,
+                    "incomplete proof"
+                );
+                bytes memory nodeData = proofIter.proof[proofIter.offset];
+                proofIter.offset++;
+                return decodeNode(nodeData, prefix, false);
+            } else {
+                return decodeNode(child.data, prefix, true);
+            }
+        } else {
+            require(child.data.length == 32, "invalid child reference");
+            revert("extraneous hash reference");
+        }
+    }
+
+    function advanceItem(StackEntry memory entry, ItemsIter memory itemsIter)
+        internal
+        pure
+        returns (Step, bytes memory childPrefix)
+    {
+        while (itemsIter.offset < itemsIter.items.length) {
+            Item memory item = itemsIter.items[itemsIter.offset];
+            bytes memory k = Nibble.keyToNibbles(item.key);
+            bytes memory v = item.value;
+            if (startsWith(k, entry.prefix)) {
+                ValueMatch vm;
+                (vm, childPrefix) = matchKeyToNode(
+                    k,
+                    entry.prefix.length,
+                    entry
+                );
+                if (ValueMatch.MatchesLeaf == vm) {
+                    if (v.length == 0) {
+                        revert("value mismatch");
+                    }
+                    entry.value = v;
+                } else if (ValueMatch.MatchesBranch == vm) {
+                    entry.value = v;
+                } else if (ValueMatch.NotFound == vm) {
+                    if (v.length > 0) {
+                        revert("value mismatch");
+                    }
+                } else if (ValueMatch.NotOmitted == vm) {
+                    revert("extraneouts value");
+                } else if (ValueMatch.IsChild == vm) {
+                    return (Step.Descend, childPrefix);
+                }
+                itemsIter.offset++;
+                continue;
+            }
+            return (Step.UnwindStack, childPrefix);
+        }
+        return (Step.UnwindStack, childPrefix);
+    }
+
+    function matchKeyToNode(
+        bytes memory k,
+        uint256 prefixLen,
+        StackEntry memory entry
+    ) internal pure returns (ValueMatch vm, bytes memory childPrefix) {
+        uint256 prefixPlufPartialLen = prefixLen + entry.key.length;
+        if (entry.kind == NODEKIND_NOEXT_LEAF) {
+            if (
+                contains(k, entry.key, prefixLen) &&
+                k.length == prefixPlufPartialLen
+            ) {
+                if (entry.value.length == 0) {
+                    return (ValueMatch.MatchesLeaf, childPrefix);
+                } else {
+                    return (ValueMatch.NotOmitted, childPrefix);
+                }
+            } else {
+                return (ValueMatch.NotFound, childPrefix);
+            }
+        } else if (
+            entry.kind == NODEKIND_NOEXT_BRANCH_NOVALUE ||
+            entry.kind == NODEKIND_NOEXT_BRANCH_WITHVALUE
+        ) {
+            if (contains(k, entry.key, prefixLen)) {
+                if (prefixPlufPartialLen == k.length) {
+                    if (entry.value.length == 0) {
+                        return (ValueMatch.MatchesBranch, childPrefix);
+                    } else {
+                        return (ValueMatch.NotOmitted, childPrefix);
+                    }
+                } else {
+                    uint8 index = uint8(k[prefixPlufPartialLen]);
+                    if (entry.children[index].exist) {
+                        childPrefix = k.substr(0, prefixPlufPartialLen + 1);
+                        return (ValueMatch.IsChild, childPrefix);
+                    } else {
+                        return (ValueMatch.NotFound, childPrefix);
+                    }
+                }
+            } else {
+                return (ValueMatch.NotFound, childPrefix);
+            }
+        } else {
+            revert("not support node type");
+        }
+    }
+
+    function contains(
+        bytes memory a,
+        bytes memory b,
+        uint256 offset
+    ) internal pure returns (bool) {
+        if (a.length < b.length + offset) {
+            return false;
+        }
+        for (uint256 i = 0; i < b.length; i++) {
+            if (a[i + offset] != b[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    function startsWith(bytes memory a, bytes memory b)
+        internal
+        pure
+        returns (bool)
+    {
+        if (a.length < b.length) {
+            return false;
+        }
+        for (uint256 i = 0; i < b.length; i++) {
+            if (a[i] != b[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * @dev Encode a Node.
+     *      encoding has the following format:
+     *      NodeHeader | Extra partial key length | Partial Key | Value
+     * @param entry The stackEntry.
+     * @return The encoded branch.
+     */
+    function encodeNode(StackEntry memory entry)
+        internal
+        view
+        returns (bytes memory)
+    {
+        if (entry.kind == NODEKIND_NOEXT_LEAF) {
+            Node.Leaf memory l = Node.Leaf({
+                key: entry.key,
+                value: entry.value
+            });
+            return Node.encodeLeaf(l);
+        } else if (
+            entry.kind == NODEKIND_NOEXT_BRANCH_NOVALUE ||
+            entry.kind == NODEKIND_NOEXT_BRANCH_WITHVALUE
+        ) {
+            Node.Branch memory b = Node.Branch({
+                key: entry.key,
+                value: entry.value,
+                children: entry.children
+            });
+            return Node.encodeBranch(b);
+        } else {
+            revert("not support node kind");
+        }
+    }
+
+    /**
+     * @dev Decode a Node.
+     *      encoding has the following format:
+     *      NodeHeader | Extra partial key length | Partial Key | Value
+     * @param nodeData The encoded trie node data.
+     * @param prefix The nibble path to the node.
+     * @param isInline The node is an in-line node or not.
+     * @return The stackEntry.
+     */
+    function decodeNode(
+        bytes memory nodeData,
+        bytes memory prefix,
+        bool isInline
+    ) internal pure returns (StackEntry memory entry) {
+        Input.Data memory data = Input.from(nodeData);
+        uint8 header = data.decodeU8();
+        uint8 kind = header >> 6;
+        if (kind == NODEKIND_NOEXT_LEAF) {
+            //Leaf
+            Node.Leaf memory leaf = Node.decodeLeaf(data, header);
+            entry.key = leaf.key;
+            entry.value = leaf.value;
+            entry.kind = kind;
+            entry.prefix = prefix;
+            entry.isInline = isInline;
+        } else if (
+            kind == NODEKIND_NOEXT_BRANCH_NOVALUE ||
+            kind == NODEKIND_NOEXT_BRANCH_WITHVALUE
+        ) {
+            //BRANCH_WITHOUT_MASK_NO_EXT  BRANCH_WITH_MASK_NO_EXT
+            Node.Branch memory branch = Node.decodeBranch(data, header);
+            entry.key = branch.key;
+            entry.value = branch.value;
+            entry.kind = kind;
+            entry.children = branch.children;
+            entry.childIndex = 0;
+            entry.prefix = prefix;
+            entry.isInline = isInline;
+        } else {
+            revert("not support node kind");
+        }
+    }
+}

--- a/contracts/MerkleProof.t.sol
+++ b/contracts/MerkleProof.t.sol
@@ -1,0 +1,153 @@
+pragma solidity >=0.5.0 <0.6.0;
+
+import "./ds-test/test.sol";
+
+import "./MerkleProof.sol";
+pragma experimental ABIEncoderV2;
+
+contract MerkleProofTest is MerkleProof, DSTest {
+    function setUp() public {}
+
+    function testFail_basic_sanity() public {
+        assertTrue(false);
+    }
+
+    function test_basic_sanity() public {
+        assertTrue(true);
+    }
+
+    function testSimplePairVerifyProof() public returns(bool) {
+
+        bytes32 root = hex"36d59226dcf98198b07207ee154ebea246a687d8c11191f35b475e7a63f9e5b4";
+        bytes[] memory proof = new bytes[](1);
+        proof[0] = hex"44646f00";
+        bytes[] memory keys = new bytes[](1);
+        keys[0] = hex"646f";
+        bytes[] memory values = new bytes[](1);
+        values[0] = hex"76657262";
+        bool res = verify(root, proof, keys, values);
+        assertTrue(res);
+    }
+
+    function testPairVerifyProof() public returns(bool) {
+
+        bytes32 root = hex"e24f300814d2ddbb2a6ba465cdc2d31004aee7741d0a4964b879f25053b2ed48";
+        bytes[] memory merkleProof = new bytes[](3);
+        merkleProof[0] = hex"c4646f4000107665726200";
+        merkleProof[1] = hex"c107400014707570707900";
+        merkleProof[2] = hex"410500";
+
+        bytes[] memory keys = new bytes[](1);
+        keys[0] = hex"646f6765";
+        bytes[] memory values = new bytes[](1);
+        values[0] = hex"0000000000000000000000000000000000000000000000000000000000000000";
+        bool res = verify(root, merkleProof, keys, values);
+        assertTrue(res);
+    }
+
+    function testPairsVerifyProofBlake2b() public returns(bool) {
+
+        bytes32 root = hex"8b5b6ad240751b4af62bf0e939731564bfb41b9bfbe01e32e00154eae31cfe43";
+        bytes[] memory merkleProof = new bytes[](1);
+        merkleProof[0] = hex"810006000c420200144203080405";
+
+        bytes[] memory keys = new bytes[](1);
+        keys[0] = hex"0102";
+        bytes[] memory values = new bytes[](1);
+        values[0] = hex"01";
+        bool res = verify(root, merkleProof, keys, values);
+        assertTrue(res);
+    }
+
+    // function testPairVerifyProofBlake2b() public {
+    //         bytes32 root
+    //      = hex"2a6b9a056f6336ab2417eedcc455a18abd01517c0a4a9adb958699eed84d8b4b";
+    //     bytes[] memory merkleProof = new bytes[](4);
+    //     merkleProof[0] = hex"80490c80b0eadd9230e584b47e00b7cf8e1f927cee0d50485a3c676a11b384ead2bf36ee80bc95ec1b2225e13c653524cb1ff8714173c780ef580581ff66c9604e7fb536c380fda12eddcd0a2e270526fc0037de9da9dcda5c99049e1f74a520c5cbd85db96b8064d657470e1a79e65884b81f1085d11308fd3182d566ffe2b419413ce0495e1980a60aa390511c25e70c1b029d951ef2fd0255b8a3fc3580bed4c4b2fa31789781";
+    //     merkleProof[1] = hex"80fffb80fbd313c51ce7764956f81ef87ff3ebc489b3232cfed8fef9a8434b7414d6f7c880760034d4c3469cab2f0c3c5417980460d295fd8b49cff262a4afb8290c38a57b80150154959b53b033e56db6cb65aa2fedca9dd0071f25eae7ba262841eaf0dbbd807adb48ce7c7686a6b1f726eca635aecf163fcb1ec47f7cacec194be9f340d7b1805c72f25b1b6304d16667e2766fa1a906cb081788eb4502787df7c3597412b17b802d39230527f49cf88fbdd4bf7e3dbcd564218ea2c20751ee4e4e24ecb44989a5800eb754c27d6302344f80fc4f785eae09c7c6acf58ee0ebddbd2f1755eb37a7de806246fab7082d42447ff6a3e4653cb8c2427408eae98af0c40f9c636b972f91548034260342013b628b1a3409a53683bd72866b974fc4bb1e2db0b50c4abd88df0680468f4c745f210c713c8eee6d4bc90e15ac9e708974088d1bf5e01db7fc0781bb809d5adec17d1f91d73f0a631ffe17af9dae7007f69f11bc4d46ca2b9777a921688090e4fe33f4b3a304329c97d1ee3cb8240585cd8c4a1da47f79423a1d91dd1d7180a7a88069a098bb5725ce52c5cf702bed3b1f6f134a69f585d43ab497995fd35280cbcdf9de3ff34d475ef3dad95c4217e6ee4a1e40897550291620d88e1a77c2bd806440a709fcb73133283c13668a87da24982f6b61060d169deb5a43532b553318";
+    //     merkleProof[2] = hex"5f00d41e5e16056765bc8461851072c9d74505240000000000000080e36a09000000000200000001000000000000000000000000000200000002000000000000ca9a3b00000000020000000300000000030e017b1e76c223d1fa5972b6e3706100bb8ddffb0aeafaf0200822520118a87e00000300000003000e017b1e76c223d1fa5972b6e3706100bb8ddffb0aeafaf0200822520118a87ef0a4b9550b000000000000000000000000000300000003020d584a4cbbfd9a4878d816512894e65918e54fae13df39a6f520fc90caea2fb00e017b1e76c223d1fa5972b6e3706100bb8ddffb0aeafaf0200822520118a87ef0a4b9550b00000000000000000000000000030000000e060017640700000000000000000000000000000300000003045a9ae1e0730536617c67ca727de00d4d197eb6afa03ac0b4ecaa097eb87813d6c005d9010000000000000000000000000000030000000000c0769f0b00000000000000";
+    //     merkleProof[3] = hex"9eaa394eea5630e07c48ae0c9558cef7098d585f0a98fdbe9ce6c55837576c60c7af3850100900000080a4adb17d600ad56fb70d03060fc70c9636b53bac26f3d45a525461b3d9fbd8ea80950043f807c1289b7636f6a759abc843caa0f2da40d133ff2fe8821926fd7d93803520a0cde9eee6081349f75cb2771853207aa1b0136c1303677c394d3b2de74880dc4f83e9b8934c4dcffc1d12f846210d0b469982edff3c19c3e89246d9f9b27a705f09cce9c888469bb1a0dceaa129672ef8284820706f6c6b61646f74";
+
+    //     bytes[] memory keys = new bytes[](1);
+    //     keys[0] = hex"26aa394eea5630e07c48ae0c9558cef780d41e5e16056765bc8461851072c9d7";
+    //     bytes[] memory values = new bytes[](1);
+    //     values[0] = hex"240000000000000080e36a09000000000200000001000000000000000000000000000200000002000000000000ca9a3b00000000020000000300000000030e017b1e76c223d1fa5972b6e3706100bb8ddffb0aeafaf0200822520118a87e00000300000003000e017b1e76c223d1fa5972b6e3706100bb8ddffb0aeafaf0200822520118a87ef0a4b9550b000000000000000000000000000300000003020d584a4cbbfd9a4878d816512894e65918e54fae13df39a6f520fc90caea2fb00e017b1e76c223d1fa5972b6e3706100bb8ddffb0aeafaf0200822520118a87ef0a4b9550b00000000000000000000000000030000000e060017640700000000000000000000000000000300000003045a9ae1e0730536617c67ca727de00d4d197eb6afa03ac0b4ecaa097eb87813d6c005d9010000000000000000000000000000030000000000c0769f0b00000000000000";
+    //     bool res = verify(root, merkleProof, keys, values);
+    //     assertTrue(res);
+    // }
+
+    function testPairsVerifyProof() public returns(bool) {
+
+        bytes32 root = hex"493825321d9ad0c473bbf85e1a08c742b4a0b75414f890745368b8953b873017";
+        bytes[] memory merkleProof = new bytes[](5);
+        merkleProof[0] = hex"810616010018487261766f00007c8306f7240030447365207374616c6c696f6e30447365206275696c64696e67";
+        merkleProof[1] = hex"466c6661800000000000000000000000000000000000000000000000000000000000000000";
+        merkleProof[2] = hex"826f400000";
+        merkleProof[3] = hex"8107400000";
+        merkleProof[4] = hex"410500";
+
+        //sort keys!
+        bytes[] memory keys = new bytes[](8);
+        keys[0] = hex"616c6661626574";
+        keys[1] = hex"627261766f";
+        keys[2] = hex"64";
+        keys[3] = hex"646f";
+        keys[4] = hex"646f10";
+        keys[5] = hex"646f67";
+        keys[6] = hex"646f6765";
+        keys[7] = hex"68616c70";
+
+        bytes[] memory values = new bytes[](8);
+        values[0] = hex"";
+        values[1] = hex"627261766f";
+        values[2] = hex"";
+        values[3] = hex"76657262";
+        values[4] = hex"";
+        values[5] = hex"7075707079";
+        values[6] = hex"0000000000000000000000000000000000000000000000000000000000000000";
+        values[7] = hex"";
+        bool res = verify(root, merkleProof, keys, values);
+        assertTrue(res);
+    }
+
+    function test_decode_leaf() public returns(bool) {
+        bytes memory proof = hex"410500";
+        Input.Data memory data = Input.from(proof);
+        uint8 header = data.decodeU8();
+        Node.Leaf memory l = Node.decodeLeaf(data, header);
+        assertEq0(l.key, hex"05");
+        assertEq0(l.value, hex"");
+    }
+
+    function test_encode_leaf() public returns(bool) {
+        bytes memory proof = hex"410500";
+        Input.Data memory data = Input.from(proof);
+        uint8 header = data.decodeU8();
+        Node.Leaf memory l = Node.decodeLeaf(data, header);
+        bytes memory b = Node.encodeLeaf(l);
+        assertEq0(proof, b);
+    }
+
+    function test_decode_branch() public returns(bool) {
+
+            bytes memory proof
+         = hex"c10740001470757070798083809f19c0b956a97fc0175e6717d289bb0f890a67a953eb0874f89244314b34";
+        Input.Data memory data = Input.from(proof);
+        uint8 header = data.decodeU8();
+        Node.Branch memory b = Node.decodeBranch(data, header);
+        assertEq0(b.key, hex"07");
+        assertEq0(b.value, hex"7075707079");
+        //TODO:: test children
+    }
+
+    function test_encode_branch() public returns(bool) {
+
+            bytes memory proof
+         = hex"c10740001470757070798083809f19c0b956a97fc0175e6717d289bb0f890a67a953eb0874f89244314b34";
+        Input.Data memory data = Input.from(proof);
+        uint8 header = data.decodeU8();
+        Node.Branch memory b = Node.decodeBranch(data, header);
+        bytes memory x = Node.encodeBranch(b);
+        assertEq0(proof, x);
+    }
+}

--- a/contracts/common/Bytes.sol
+++ b/contracts/common/Bytes.sol
@@ -1,0 +1,64 @@
+pragma solidity >=0.5.0 <0.6.0;
+
+import {Memory} from "./Memory.sol";
+
+library Bytes {
+    uint256 internal constant BYTES_HEADER_SIZE = 32;
+
+    // Copies a section of 'self' into a new array, starting at the provided 'startIndex'.
+    // Returns the new copy.
+    // Requires that 'startIndex <= self.length'
+    // The length of the substring is: 'self.length - startIndex'
+    function substr(bytes memory self, uint256 startIndex)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        require(startIndex <= self.length);
+        uint256 len = self.length - startIndex;
+        uint256 addr = Memory.dataPtr(self);
+        return Memory.toBytes(addr + startIndex, len);
+    }
+
+    // Copies 'len' bytes from 'self' into a new array, starting at the provided 'startIndex'.
+    // Returns the new copy.
+    // Requires that:
+    //  - 'startIndex + len <= self.length'
+    // The length of the substring is: 'len'
+    function substr(
+        bytes memory self,
+        uint256 startIndex,
+        uint256 len
+    ) internal pure returns (bytes memory) {
+        require(startIndex + len <= self.length);
+        if (len == 0) {
+            return "";
+        }
+        uint256 addr = Memory.dataPtr(self);
+        return Memory.toBytes(addr + startIndex, len);
+    }
+
+    // Combines 'self' and 'other' into a single array.
+    // Returns the concatenated arrays:
+    //  [self[0], self[1], ... , self[self.length - 1], other[0], other[1], ... , other[other.length - 1]]
+    // The length of the new array is 'self.length + other.length'
+    function concat(bytes memory self, bytes memory other)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        bytes memory ret = new bytes(self.length + other.length);
+        uint256 src;
+        uint256 srcLen;
+        (src, srcLen) = Memory.fromBytes(self);
+        uint256 src2;
+        uint256 src2Len;
+        (src2, src2Len) = Memory.fromBytes(other);
+        uint256 dest;
+        (dest, ) = Memory.fromBytes(ret);
+        uint256 dest2 = dest + srcLen;
+        Memory.copy(src, dest, srcLen);
+        Memory.copy(src2, dest2, src2Len);
+        return ret;
+    }
+}

--- a/contracts/common/Hash.sol
+++ b/contracts/common/Hash.sol
@@ -1,0 +1,12 @@
+pragma solidity >=0.5.0 <0.6.0;
+
+import "./Memory.sol";
+import "../Blake2b.sol";
+
+library Hash {
+    function hash(bytes memory src) internal view returns (bytes memory des) {
+        return Memory.toBytes(keccak256(src));
+        // Blake2b.Instance memory instance = Blake2b.init(hex"", 32);
+        // return instance.finalize(src);
+    }
+}

--- a/contracts/common/Input.sol
+++ b/contracts/common/Input.sol
@@ -1,0 +1,58 @@
+pragma solidity >=0.5.0 <0.6.0;
+
+import "./Bytes.sol";
+
+library Input {
+    using Bytes for bytes;
+
+    struct Data {
+        uint256 offset;
+        bytes raw;
+    }
+
+    function from(bytes memory data) internal pure returns (Data memory) {
+        return Data({offset: 0, raw: data});
+    }
+
+    modifier shift(Data memory data, uint256 size) {
+        require(data.raw.length >= data.offset + size, "Input: Out of range");
+        _;
+        data.offset += size;
+    }
+
+    function finished(Data memory data) internal pure returns (bool) {
+        return data.offset == data.raw.length;
+    }
+
+    function peekU8(Data memory data) internal pure returns (uint8 v) {
+        return uint8(data.raw[data.offset]);
+    }
+
+    function decodeU8(Data memory data)
+        internal
+        pure
+        shift(data, 1)
+        returns (uint8 value)
+    {
+        value = uint8(data.raw[data.offset]);
+    }
+
+    function decodeU16(Data memory data) internal pure returns (uint16 value) {
+        value = uint16(decodeU8(data));
+        value |= (uint16(decodeU8(data)) << 8);
+    }
+
+    function decodeU32(Data memory data) internal pure returns (uint32 value) {
+        value = uint32(decodeU16(data));
+        value |= (uint32(decodeU16(data)) << 16);
+    }
+
+    function decodeBytesN(Data memory data, uint256 N)
+        internal
+        pure
+        shift(data, N)
+        returns (bytes memory value)
+    {
+        value = data.raw.substr(data.offset, N);
+    }
+}

--- a/contracts/common/Memory.sol
+++ b/contracts/common/Memory.sol
@@ -1,0 +1,66 @@
+pragma solidity >=0.5.0 <0.6.0;
+
+library Memory {
+
+    uint internal constant WORD_SIZE = 32;
+	
+	// Returns a memory pointer to the data portion of the provided bytes array.
+	function dataPtr(bytes memory bts) internal pure returns (uint addr) {
+		assembly {
+			addr := add(bts, /*BYTES_HEADER_SIZE*/32)
+		}
+	}
+
+	// Creates a 'bytes memory' variable from the memory address 'addr', with the
+	// length 'len'. The function will allocate new memory for the bytes array, and
+	// the 'len bytes starting at 'addr' will be copied into that new memory.
+	function toBytes(uint addr, uint len) internal pure returns (bytes memory bts) {
+		bts = new bytes(len);
+		uint btsptr;
+		assembly {
+			btsptr := add(bts, /*BYTES_HEADER_SIZE*/32)
+		}
+		copy(addr, btsptr, len);
+	}
+	
+	// Copies 'self' into a new 'bytes memory'.
+	// Returns the newly created 'bytes memory'
+	// The returned bytes will be of length '32'.
+	function toBytes(bytes32 self) internal pure returns (bytes memory bts) {
+		bts = new bytes(32);
+		assembly {
+			mstore(add(bts, /*BYTES_HEADER_SIZE*/32), self)
+		}
+	}
+
+	// Copy 'len' bytes from memory address 'src', to address 'dest'.
+	// This function does not check the or destination, it only copies
+	// the bytes.
+	function copy(uint src, uint dest, uint len) internal pure {
+		// Copy word-length chunks while possible
+		for (; len >= WORD_SIZE; len -= WORD_SIZE) {
+			assembly {
+				mstore(dest, mload(src))
+			}
+			dest += WORD_SIZE;
+			src += WORD_SIZE;
+		}
+
+		// Copy remaining bytes
+		uint mask = 256 ** (WORD_SIZE - len) - 1;
+		assembly {
+			let srcpart := and(mload(src), not(mask))
+			let destpart := and(mload(dest), mask)
+			mstore(dest, or(destpart, srcpart))
+		}
+	}
+
+	// This function does the same as 'dataPtr(bytes memory)', but will also return the
+	// length of the provided bytes array.
+	function fromBytes(bytes memory bts) internal pure returns (uint addr, uint len) {
+		len = bts.length;
+		assembly {
+			addr := add(bts, /*BYTES_HEADER_SIZE*/32)
+		}
+	}
+}

--- a/contracts/common/Nibble.sol
+++ b/contracts/common/Nibble.sol
@@ -1,0 +1,47 @@
+pragma solidity >=0.5.0 <0.6.0;
+
+library Nibble {
+    // keyToNibbles turns bytes into nibbles, assumes they are already ordered in LE
+    function keyToNibbles(bytes memory src)
+        internal
+        pure
+        returns (bytes memory des)
+    {
+        if (src.length == 0) {
+            return des;
+        } else if (src.length == 1 && uint8(src[0]) == 0) {
+            return hex"0000";
+        }
+        uint256 l = src.length * 2;
+        des = new bytes(l);
+        for (uint256 i = 0; i < src.length; i++) {
+            des[2 * i] = bytes1(uint8(src[i]) / 16);
+            des[2 * i + 1] = bytes1(uint8(src[i]) % 16);
+        }
+    }
+
+    // nibblesToKeyLE turns a slice of nibbles w/ length k into a little endian byte array, assumes nibbles are already LE
+    function nibblesToKeyLE(bytes memory src)
+        internal
+        pure
+        returns (bytes memory des)
+    {
+        uint256 l = src.length;
+        if (l % 2 == 0) {
+            des = new bytes(l / 2);
+            for (uint256 i = 0; i < l; i += 2) {
+                uint8 a = uint8(src[i]);
+                uint8 b = uint8(src[i + 1]);
+                des[i / 2] = bytes1(((a << 4) & 0xF0) | (b & 0x0F));
+            }
+        } else {
+            des = new bytes(l / 2 + 1);
+            des[0] = src[0];
+            for (uint256 i = 2; i < l; i += 2) {
+                uint8 a = uint8(src[i - 1]);
+                uint8 b = uint8(src[i]);
+                des[i / 2] = bytes1(((a << 4) & 0xF0) | (b & 0x0F));
+            }
+        }
+    }
+}

--- a/contracts/common/Node.sol
+++ b/contracts/common/Node.sol
@@ -1,0 +1,233 @@
+pragma solidity >=0.5.0 <0.6.0;
+
+import "./Input.sol";
+import "./Nibble.sol";
+import "./Bytes.sol";
+import "./Hash.sol";
+import "./Scale.sol";
+
+library Node {
+    using Input for Input.Data;
+    using Bytes for bytes;
+
+    uint8 internal constant NODEKIND_NOEXT_LEAF = 1;
+    uint8 internal constant NODEKIND_NOEXT_BRANCH_NOVALUE = 2;
+    uint8 internal constant NODEKIND_NOEXT_BRANCH_WITHVALUE = 3;
+
+    struct NodeHandle {
+        bytes data;
+        bool exist;
+        bool isInline;
+    }
+
+    struct Branch {
+        bytes key; //partialkey
+        NodeHandle[16] children;
+        bytes value;
+    }
+
+    struct Leaf {
+        bytes key; //partialkey
+        bytes value;
+    }
+
+    // decodeBranch decodes a byte array into a branch node
+    function decodeBranch(Input.Data memory data, uint8 header)
+        internal
+        pure
+        returns (Branch memory)
+    {
+        Branch memory b;
+        b.key = decodeNodeKey(data, header);
+        uint8[2] memory bitmap;
+        bitmap[0] = data.decodeU8();
+        bitmap[1] = data.decodeU8();
+        uint8 nodeType = header >> 6;
+        if (nodeType == NODEKIND_NOEXT_BRANCH_WITHVALUE) {
+            //BRANCH_WITH_MASK_NO_EXT
+            b.value = Scale.decodeByteArray(data);
+        }
+        for (uint8 i = 0; i < 16; i++) {
+            if (((bitmap[i / 8] >> (i % 8)) & 1) == 1) {
+                bytes memory childData = Scale.decodeByteArray(data);
+                bool isInline = true;
+                if (childData.length == 32) {
+                    isInline = false;
+                }
+                b.children[i] = NodeHandle({
+                    data: childData,
+                    isInline: isInline,
+                    exist: true
+                });
+            }
+        }
+        return b;
+    }
+
+    // decodeLeaf decodes a byte array into a leaf node
+    function decodeLeaf(Input.Data memory data, uint8 header)
+        internal
+        pure
+        returns (Leaf memory)
+    {
+        Leaf memory l;
+        l.key = decodeNodeKey(data, header);
+        l.value = Scale.decodeByteArray(data);
+        return l;
+    }
+
+    function decodeNodeKey(Input.Data memory data, uint8 header)
+        internal
+        pure
+        returns (bytes memory key)
+    {
+        uint256 keyLen = header & 0x3F;
+        if (keyLen == 0x3f) {
+            while (keyLen < 65536) {
+                uint8 nextKeyLen = data.decodeU8();
+                keyLen += uint256(nextKeyLen);
+                if (nextKeyLen < 0xFF) {
+                    break;
+                }
+                require(
+                    keyLen < 65536,
+                    "Size limit reached for a nibble slice"
+                );
+            }
+        }
+        if (keyLen != 0) {
+            key = data.decodeBytesN(keyLen / 2 + (keyLen % 2));
+            key = Nibble.keyToNibbles(key);
+            if (keyLen % 2 == 1) {
+                key = key.substr(1);
+            }
+        }
+        return key;
+    }
+
+    // encodeBranch encodes a branch
+    function encodeBranch(Branch memory b)
+        internal
+        view
+        returns (bytes memory encoding)
+    {
+        encoding = encodeBranchHeader(b);
+        encoding = abi.encodePacked(encoding, Nibble.nibblesToKeyLE(b.key));
+        encoding = abi.encodePacked(encoding, u16ToBytes(childrenBitmap(b)));
+        if (b.value.length != 0) {
+            bytes memory encValue;
+            (encValue, ) = Scale.encodeByteArray(b.value);
+            encoding = abi.encodePacked(encoding, encValue);
+        }
+        for (uint8 i = 0; i < 16; i++) {
+            if (b.children[i].exist) {
+                //TODO::encode data
+                bytes memory childData = b.children[i].data;
+                require(childData.length > 0, "miss child data");
+                bytes memory hash;
+                if (childData.length <= 32) {
+                    hash = childData;
+                } else {
+                    hash = Hash.hash(childData);
+                }
+                bytes memory encChild;
+                (encChild, ) = Scale.encodeByteArray(hash);
+                encoding = abi.encodePacked(encoding, encChild);
+            }
+        }
+        return encoding;
+    }
+
+    // encodeLeaf encodes a leaf
+    function encodeLeaf(Leaf memory l)
+        internal
+        pure
+        returns (bytes memory encoding)
+    {
+        encoding = encodeLeafHeader(l);
+        encoding = abi.encodePacked(encoding, Nibble.nibblesToKeyLE(l.key));
+        bytes memory encValue;
+        (encValue, ) = Scale.encodeByteArray(l.value);
+        encoding = abi.encodePacked(encoding, encValue);
+        return encoding;
+    }
+
+    function encodeBranchHeader(Branch memory b)
+        internal
+        pure
+        returns (bytes memory branchHeader)
+    {
+        uint8 header;
+        uint256 valueLen = b.value.length;
+        require(valueLen < 65536, "partial key too long");
+        if (valueLen == 0) {
+            header = 2 << 6; // w/o
+        } else {
+            header = 3 << 6; // w/
+        }
+        bytes memory encPkLen;
+        uint256 pkLen = b.key.length;
+        if (pkLen >= 63) {
+            header = header | 0x3F;
+            encPkLen = encodeExtraPartialKeyLength(uint16(pkLen));
+        } else {
+            header = header | uint8(pkLen);
+        }
+        branchHeader = abi.encodePacked(header, encPkLen);
+        return branchHeader;
+    }
+
+    function encodeLeafHeader(Leaf memory l)
+        internal
+        pure
+        returns (bytes memory leafHeader)
+    {
+        uint8 header = 1 << 6;
+        uint256 pkLen = l.key.length;
+        bytes memory encPkLen;
+        if (pkLen >= 63) {
+            header = header | 0x3F;
+            encPkLen = encodeExtraPartialKeyLength(uint16(pkLen));
+        } else {
+            header = header | uint8(pkLen);
+        }
+        leafHeader = abi.encodePacked(header, encPkLen);
+        return leafHeader;
+    }
+
+    function encodeExtraPartialKeyLength(uint16 pkLen)
+        internal
+        pure
+        returns (bytes memory encPkLen)
+    {
+        pkLen -= 63;
+        for (uint8 i = 0; i < 65536; i++) {
+            if (pkLen < 255) {
+                encPkLen = abi.encodePacked(encPkLen, uint8(pkLen));
+                break;
+            } else {
+                encPkLen = abi.encodePacked(encPkLen, uint8(255));
+            }
+        }
+        return encPkLen;
+    }
+
+    // u16ToBytes converts a uint16 into a 2-byte slice
+    function u16ToBytes(uint16 src) internal pure returns (bytes memory des) {
+        des = new bytes(2);
+        des[0] = bytes1(uint8(src & 0x00FF));
+        des[1] = bytes1(uint8((src >> 8) & 0x00FF));
+    }
+
+    function childrenBitmap(Branch memory b)
+        internal
+        pure
+        returns (uint16 bitmap)
+    {
+        for (uint256 i = 0; i < 16; i++) {
+            if (b.children[i].exist) {
+                bitmap = bitmap | uint16(1 << i);
+            }
+        }
+    }
+}

--- a/contracts/common/Scale.sol
+++ b/contracts/common/Scale.sol
@@ -1,0 +1,92 @@
+pragma solidity >=0.5.0 <0.6.0;
+
+import "./Input.sol";
+
+library Scale {
+    using Input for Input.Data;
+
+    // decodeByteArray accepts a byte array representing a SCALE encoded byte array and performs SCALE decoding
+    // of the byte array
+    function decodeByteArray(Input.Data memory data)
+        internal
+        pure
+        returns (bytes memory v)
+    {
+        uint32 len = decodeU32(data);
+        if (len == 0) {
+            return v;
+        }
+        v = data.decodeBytesN(len);
+        return v;
+    }
+
+    // decodeU32 accepts a byte array representing a SCALE encoded integer and performs SCALE decoding of the smallint
+    function decodeU32(Input.Data memory data) internal pure returns (uint32) {
+        uint8 b0 = data.decodeU8();
+        uint8 mode = b0 & 3;
+        require(mode <= 2, "scale decode not support");
+        if (mode == 0) {
+            return uint32(b0) >> 2;
+        } else if (mode == 1) {
+            uint8 b1 = data.decodeU8();
+            uint16 v = uint16(b0) | (uint16(b1) << 8);
+            return uint32(v) >> 2;
+        } else if (mode == 2) {
+            uint8 b1 = data.decodeU8();
+            uint8 b2 = data.decodeU8();
+            uint8 b3 = data.decodeU8();
+            uint32 v = uint32(b0) |
+                (uint32(b1) << 8) |
+                (uint32(b2) << 18) |
+                (uint32(b3) << 24);
+            return v >> 2;
+        }
+    }
+
+    // encodeByteArray performs the following:
+    // b -> [encodeInteger(len(b)) b]
+    function encodeByteArray(bytes memory src)
+        internal
+        pure
+        returns (bytes memory des, uint256 bytesEncoded)
+    {
+        uint256 n;
+        (des, n) = encodeU32(uint32(src.length));
+        bytesEncoded = n + src.length;
+        des = abi.encodePacked(des, src);
+    }
+
+    // encodeU32 performs the following on integer i:
+    // i  -> i^0...i^n where n is the length in bits of i
+    // if n < 2^6 write [00 i^2...i^8 ] [ 8 bits = 1 byte encoded  ]
+    // if 2^6 <= n < 2^14 write [01 i^2...i^16] [ 16 bits = 2 byte encoded  ]
+    // if 2^14 <= n < 2^30 write [10 i^2...i^32] [ 32 bits = 4 byte encoded  ]
+    function encodeU32(uint32 i) internal pure returns (bytes memory, uint256) {
+        // 1<<6
+        if (i < 64) {
+            uint8 v = uint8(i) << 2;
+            bytes1 b = bytes1(v);
+            bytes memory des = new bytes(1);
+            des[0] = b;
+            return (des, 1);
+            // 1<<14
+        } else if (i < 16384) {
+            uint16 v = uint16(i << 2) + 1;
+            bytes memory des = new bytes(2);
+            des[0] = bytes1(uint8(v));
+            des[1] = bytes1(uint8(v >> 8));
+            return (des, 2);
+            // 1<<30
+        } else if (i < 1073741824) {
+            uint32 v = uint32(i << 2) + 2;
+            bytes memory des = new bytes(4);
+            des[0] = bytes1(uint8(v));
+            des[1] = bytes1(uint8(v >> 8));
+            des[2] = bytes1(uint8(v >> 16));
+            des[3] = bytes1(uint8(v >> 24));
+            return (des, 4);
+        } else {
+            revert("scale encode not support");
+        }
+    }
+}

--- a/contracts/ds-test/test.sol
+++ b/contracts/ds-test/test.sol
@@ -1,0 +1,144 @@
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity >=0.4.23;
+
+contract DSTest {
+    event eventListener          (address target, bool exact);
+    event logs                   (bytes);
+    event log_bytes32            (bytes32);
+    event log_named_address      (bytes32 key, address val);
+    event log_named_bytes32      (bytes32 key, bytes32 val);
+    event log_named_decimal_int  (bytes32 key, int val, uint decimals);
+    event log_named_decimal_uint (bytes32 key, uint val, uint decimals);
+    event log_named_int          (bytes32 key, int val);
+    event log_named_uint         (bytes32 key, uint val);
+    event log_named_string       (bytes32 key, string val);
+
+    bool public IS_TEST;
+    bool public failed;
+
+    constructor() internal {
+        IS_TEST = true;
+    }
+
+    function fail() internal {
+        failed = true;
+    }
+
+    function expectEventsExact(address target) internal {
+        emit eventListener(target, true);
+    }
+
+    modifier logs_gas() {
+        uint startGas = gasleft();
+        _;
+        uint endGas = gasleft();
+        emit log_named_uint("gas", startGas - endGas);
+    }
+
+    function assertTrue(bool condition) internal {
+        if (!condition) {
+            emit log_bytes32("Assertion failed");
+            fail();
+        }
+    }
+
+    function assertEq(address a, address b) internal {
+        if (a != b) {
+            emit log_bytes32("Error: Wrong `address' value");
+            emit log_named_address("  Expected", b);
+            emit log_named_address("    Actual", a);
+            fail();
+        }
+    }
+
+    function assertEq32(bytes32 a, bytes32 b) internal {
+        assertEq(a, b);
+    }
+
+    function assertEq(bytes32 a, bytes32 b) internal {
+        if (a != b) {
+            emit log_bytes32("Error: Wrong `bytes32' value");
+            emit log_named_bytes32("  Expected", b);
+            emit log_named_bytes32("    Actual", a);
+            fail();
+        }
+    }
+
+    function assertEqDecimal(int a, int b, uint decimals) internal {
+        if (a != b) {
+            emit log_bytes32("Error: Wrong fixed-point decimal");
+            emit log_named_decimal_int("  Expected", b, decimals);
+            emit log_named_decimal_int("    Actual", a, decimals);
+            fail();
+        }
+    }
+
+    function assertEqDecimal(uint a, uint b, uint decimals) internal {
+        if (a != b) {
+            emit log_bytes32("Error: Wrong fixed-point decimal");
+            emit log_named_decimal_uint("  Expected", b, decimals);
+            emit log_named_decimal_uint("    Actual", a, decimals);
+            fail();
+        }
+    }
+
+    function assertEq(int a, int b) internal {
+        if (a != b) {
+            emit log_bytes32("Error: Wrong `int' value");
+            emit log_named_int("  Expected", b);
+            emit log_named_int("    Actual", a);
+            fail();
+        }
+    }
+
+    function assertEq(uint a, uint b) internal {
+        if (a != b) {
+            emit log_bytes32("Error: Wrong `uint' value");
+            emit log_named_uint("  Expected", b);
+            emit log_named_uint("    Actual", a);
+            fail();
+        }
+    }
+
+    function assertEq(string memory a, string memory b) internal {
+        if (keccak256(abi.encodePacked(a)) != keccak256(abi.encodePacked(b))) {
+            emit log_bytes32("Error: Wrong `string' value");
+            emit log_named_string("  Expected", b);
+            emit log_named_string("    Actual", a);
+            fail();
+        }
+    }
+
+    function assertEq0(bytes memory a, bytes memory b) internal {
+        bool ok = true;
+
+        if (a.length == b.length) {
+            for (uint i = 0; i < a.length; i++) {
+                if (a[i] != b[i]) {
+                    ok = false;
+                }
+            }
+        } else {
+            ok = false;
+        }
+
+        if (!ok) {
+            emit log_bytes32("Error: Wrong `bytes' value");
+            emit log_named_bytes32("  Expected", "[cannot show `bytes' value]");
+            emit log_named_bytes32("  Actual", "[cannot show `bytes' value]");
+            fail();
+        }
+    }
+}

--- a/test/TestMerkleProof.js
+++ b/test/TestMerkleProof.js
@@ -1,0 +1,14 @@
+const MerkleProofTest = artifacts.require('MerkleProofTest');
+
+describe('MerkleProofTest', function (accounts) {
+
+    before(async () => {
+
+    });
+
+    it('MerkleProof test', async () => {
+        let contract = await MerkleProofTest.new()
+        let ret = await contract.testSimplePairVerifyProof()
+        assert(ret, true);
+    }).timeout(200000);
+});


### PR DESCRIPTION
Solidity version of verification is translated by the [Rust Version].(https://github.com/paritytech/trie/blob/f05463150c53679c083db5cb6e181fb342ee57d8/trie-db/src/proof/verify.rs#L391).
### Brief
The proof is a sequence of the subset of nodes in the trie traversed while performing lookups on all keys. The trie nodes are listed in pre-order traversal order with some values and internal hashes omitted. In particular, values on leaf nodes, child references on extension nodes, values on branch nodes corresponding to a key in the statement, and child references on branch nodes corresponding to another node in the proof are all omitted. The proof is verified by iteratively reconstructing the trie nodes using the values proving as part of the statement and the hashes of other reconstructed nodes. Since the nodes in the proof are arranged in pre-order traversal order, the construction can be done efficiently using a stack.

### Trie node encoding specification
 Note that for the following definitions, `|` denotes concatenation

 Branch encoding:
 NodeHeader | Extra partial key length | Partial Key | Value
 `NodeHeader` is a byte such that:
 most significant two bits of `NodeHeader`: 10 if branch w/o value, 11 if branch w/ value
 least significant six bits of `NodeHeader`: if len(key) > 62, 0x3f, otherwise len(key)
 `Extra partial key length` is included if len(key) > 63 and consists of the remaining key length
 `Partial Key` is the branch's key
 `Value` is: Children Bitmap | SCALE Branch node Value | Hash(Enc(Child[i_1])) | Hash(Enc(Child[i_2])) | ... | Hash(Enc(Child[i_n]))

 Leaf encoding:
 NodeHeader | Extra partial key length | Partial Key | Value
 `NodeHeader` is a byte such that:
 most significant two bits of `NodeHeader`: 01
 least significant six bits of `NodeHeader`: if len(key) > 62, 0x3f, otherwise len(key)
 `Extra partial key length` is included if len(key) > 63 and consists of the remaining key length
 `Partial Key` is the leaf's key
 `Value` is the leaf's SCALE encoded value

### Features

1. MerkleProof.sol: verication for MMPT(16-radix) generated by Substrate trie lib.
2. Node.sol: encoding and decoding for trie node.
3. Scale.sol: SCALE codec support, `bytes` and `uint32`.
4. Hash.sol: Hash algorithm support, `keccake256` and `blake2b`.
